### PR TITLE
Detect b64 data tag

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,12 +1,12 @@
 Revision history for SWISH-Filters-ImageToMD5Xml
 
-0.01    12/27/2011
-        Initial Release
+0.03 06/14/2015
+ - [Contributor: Chorny] makefile fixes
 
-0.02    12/27/2011
-        Updated Makefile.PL to have the appropriate dependencies to fix test
-        builds.
+0.02 12/27/2011
+ - Updated Makefile.PL to have the appropriate dependencies to fix test
+ - builds.
 
-0.03    06/14/2015
-        [Contributor: Chorny] makefile fixes
+0.01 12/27/2011
+ - Initial Release
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for SWISH-Filters-ImageToMD5Xml
 
+0.04 12/04/2015
+ - do not attempt to filter XML that does not contain the b64_data tag
+
 0.03 06/14/2015
  - [Contributor: Chorny] makefile fixes
 

--- a/lib/SWISH/Filters/ImageToMD5Xml.pm
+++ b/lib/SWISH/Filters/ImageToMD5Xml.pm
@@ -68,7 +68,8 @@ sub _parse_xml {
 
 =head2 filter( $self, $doc )
 
-Generates XML meta data for indexing.
+Generates XML meta data for indexing. If I<$doc> contains the C<b64_data> element (tag)
+then a MD5 checksum string will be added to the XML and returned with a new root element C<image_data>.
 
 =cut
 
@@ -77,13 +78,11 @@ sub filter {
 
     return if $doc->is_binary;
 
-    my $xml_converter = Search::Tools::XML->new();
-
     if ( my $xml = $doc->fetch_filename ) {
         if ( my $ds = $self->_parse_xml($xml) ) {
             return unless exists $ds->{b64_data};
             $ds->{md5} = md5($ds->{b64_data});
-            my $xml    = $xml_converter->perl_to_xml($ds, 'image_data', );
+            my $xml    = Search::Tools::XML->perl_to_xml($ds, { root => 'image_data' });
             $doc->set_content_type('application/xml');
             return $xml;
         }

--- a/lib/SWISH/Filters/ImageToMD5Xml.pm
+++ b/lib/SWISH/Filters/ImageToMD5Xml.pm
@@ -11,17 +11,20 @@ SWISH::Filters::ImageToMD5Xml - Adds MD5 information when filtering an image for
 
 =head1 VERSION
 
-Version 0.02
+Version 0.04
 
 =cut
 
-our $VERSION = '0.03';
-
+our $VERSION = '0.04';
 
 =head1 SYNOPSIS
 
-A SWISHE filter that takes an incoming image XML applies a MD5 checksum
-against the binary content of the image.  
+A L<SWISH::Filter> that takes an incoming image XML and applies a MD5 checksum
+against the binary content of the image.
+
+The XML structure this filter expects includes an C<b64_data> element containing
+the Base64 string representing the image. If that element (tag) is not found,
+no filter is applied.
 
 =head1 METHODS
 
@@ -74,11 +77,13 @@ sub filter {
 
     return if $doc->is_binary;
 
+    my $xml_converter = Search::Tools::XML->new();
+
     if ( my $xml = $doc->fetch_filename ) {
-        if ( my $ds  = $self->_parse_xml($xml) ) {
-            my $utils  = Search::Tools::XML->new;
+        if ( my $ds = $self->_parse_xml($xml) ) {
+            return unless exists $ds->{b64_data};
             $ds->{md5} = md5($ds->{b64_data});
-            my $xml    = $utils->perl_to_xml($ds, 'image_data', );
+            my $xml    = $xml_converter->perl_to_xml($ds, 'image_data', );
             $doc->set_content_type('application/xml');
             return $xml;
         }

--- a/t/02-xml-matching.t
+++ b/t/02-xml-matching.t
@@ -1,0 +1,28 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use Test::MockObject;
+
+use_ok('SWISH::Filters::ImageToMD5Xml');
+
+my $subject  = SWISH::Filters::ImageToMD5Xml->new;
+my $filtered = $subject->filter( get_doc() );
+
+is $filtered, undef, "leaves XML with no <b64_data> element untouched";
+
+done_testing();
+
+sub get_doc {
+    my $meta_data = shift;
+
+    my $xml = "<doc><foo>no base64 data here</foo></doc>";
+
+    my $doc = Test::MockObject->new;
+    $doc->mock( 'fetch_filename',   sub { return $xml } );
+    $doc->mock( 'set_content_type', sub { return 'application/xml' } );
+    $doc->mock( 'meta_data',        sub { return $meta_data } );
+    $doc->mock( 'is_binary',        sub { return 0 } );
+
+    return $doc;
+}


### PR DESCRIPTION
https://rt.cpan.org/Ticket/Display.html?id=110047 reports downstream failures where this filter attempts to act on XML that does not match the necessary tag. 

This PR fixes that bug and adds more documentation.
